### PR TITLE
Data Lasso now resizes with window

### DIFF
--- a/src/views/Graph.js
+++ b/src/views/Graph.js
@@ -158,6 +158,7 @@ var GraphView = Backbone.View.extend({
     onWindowResize: function () {
         this.renderer.setSize(window.innerWidth, window.innerHeight);
         this.camera.aspect = window.innerWidth / window.innerHeight;
+        this.camera.updateProjectionMatrix()
     },
 
     /**


### PR DESCRIPTION
Making Data Lasso resize with window was way easier then I expected - no need to rebuild projection planes, camera aspect ratio can be changed just like that.

Now Data Lasso will gracefully resize when you change size of your window.

@heylookltsme @kmck 
