### PR TITLE
Adding license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "graph",
     "3d"
   ],
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Tim Gilyazetdinov",
+    "email": "tim@tumblr.com"
+  },
   "devDependencies": {
     "browserify": "^12.0.1",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Forgot to add license field to `package.json` so it can be picked up by NPM.

**Open question** - author field - should it be my obnoxiously long name, or just "tumblr"?

@heylookltsme @kmck 
