### PR TITLE
Adding URL input to Data Lasso, cleaning up Uploader view

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,5 @@
 @import 'partials/variables';
+@import 'partials/animations';
 
 @import 'partials/layout';
 @import 'partials/axis-controls';

--- a/src/styles/partials/_animations.scss
+++ b/src/styles/partials/_animations.scss
@@ -1,0 +1,5 @@
+@keyframes shake {
+    0%, 100% {transform: translateX(0);}
+    10%, 40%, 70% {transform: translateX(-8px);}
+    25%, 55%, 85% {transform: translateX(8px);}
+}

--- a/src/styles/partials/_axis-controls.scss
+++ b/src/styles/partials/_axis-controls.scss
@@ -1,7 +1,7 @@
 .axis-controls {
     position: absolute;
     padding: 10px;
-    top: 130px;
+    top: 220px;
     left: 0;
     z-index: 1;
     width: 200px;

--- a/src/styles/partials/_layout.scss
+++ b/src/styles/partials/_layout.scss
@@ -8,6 +8,23 @@
     margin: 0;
     font-size: 13px;
     line-height: 1.4;
+    color: $dl-color-text;
+    font-weight: bold;
+
+    .row {
+        width: 100%;
+        margin: 5px 0;
+        display: flex;
+        justify-content: center;
+
+        &.extra-spacing {
+            margin-bottom: 10px;
+        }
+    }
+
+    .column {
+        flex: 1 0 auto;
+    }
 
     .button {
         width: 100%;
@@ -27,5 +44,14 @@
             background-color: $dl-background-subtle;
             color: $dl-color-text;
         }
+    }
+
+    .text-input {
+        box-sizing: border-box;
+        width: 100%;
+        color: $dl-color-text;
+        border: 0;
+        padding: 10px;
+        background: $dl-background-subtle;
     }
 }

--- a/src/styles/partials/_uploader.scss
+++ b/src/styles/partials/_uploader.scss
@@ -6,54 +6,90 @@
     padding: 10px;
     z-index: 1;
 
-    .toggles {
-        margin: 5px 0;
-        display: flex;
-        justify-content: center;
-    }
-
     .toggle {
-        flex: 1 0 auto;
-
-        .filetype-label {
-            text-align: center;
-            display: block;
-            cursor: pointer;
-            width: 100%;
-            font-weight: bold;
-            background: $dl-background-subtle;
-            color: #ddd;
-        }
-
-        input:checked + .filetype-label {
-            background: $dl-background-heavy;
-            color: #FFF;
-        }
-
-        input {
-            display: none;
-        }
-    }
-
-    .file-upload {
+        text-align: center;
+        display: block;
+        cursor: pointer;
         width: 100%;
-        padding: 4px 0;
-        height: auto;
-        line-height: 1;
-        color: $dl-color-text;
+        font-weight: bold;
         background: $dl-background-subtle;
+        color: $dl-color-text;
+        border: 0;
+        font-size: inherit;
     }
 
-    .upload-button {
+    .toggle.active {
+        background: $dl-background-heavy;
+        color: #ffffff;
+    }
+
+    .file-upload-input {
+        width: 100%;
+        color: $dl-color-text;
+        padding: 7px 0;
+    }
+
+    .url-input:focus {
+        width: 200%;
+    }
+
+    .button {
         .loading-state {
             display: none;
         }
     }
 
-    &.loading {
-        .upload-button {
-            pointer-events: none;
+    &[data-source='file'] {
+        .file-upload-form {
+            display: block;
+        }
 
+        .url-form {
+            display: none;
+        }
+
+        .toggle-file {
+            @extend .active;
+        }
+    }
+
+    &[data-source='url'] {
+        .file-upload-form {
+            display: none;
+        }
+
+        .url-form {
+            display: block;
+        }
+
+        .toggle-url {
+            @extend .active;
+        }
+    }
+
+    &[data-file-type='csv'] {
+        .toggle-csv {
+            @extend .active;
+        }
+    }
+
+    &[data-file-type='tsv'] {
+        .toggle-tsv {
+            @extend .active;
+        }
+    }
+
+    &[data-file-type='json'] {
+        .toggle-json {
+            @extend .active;
+        }
+    }
+
+    &.loading {
+        opacity: 0.5;
+        pointer-events: none;
+
+        .button {
             .loading-state {
                 display: block;
             }
@@ -61,6 +97,12 @@
             .ready-state {
                 display: none;
             }
+        }
+    }
+
+    &.error {
+        .button {
+            animation: shake 0.6s;
         }
     }
 }

--- a/src/templates/uploader.tpl
+++ b/src/templates/uploader.tpl
@@ -1,23 +1,48 @@
-<form class="upload-form">
-    <input type="file" class="file-upload">
+<div class="row">DATA SOURCE</div>
 
-    <div class="toggles">
-        <div class="toggle">
-            <input type="radio" value="csv" name="type" id="csv" checked="checked">
-            <label class="filetype-label" for="csv">CSV</label>
-        </div>
-        <div class="toggle">
-            <input type="radio" value="tsv" name="type" id="tsv">
-            <label class="filetype-label" for="tsv">TSV</label>
-        </div>
-        <div class="toggle">
-            <input type="radio" value="json" name="type" id="json">
-            <label class="filetype-label" for="json">JSON</label>
-        </div>
+<div class="row extra-spacing">
+    <div class="column">
+        <button data-js-selector="data-source-toggle" data-source="file" class="toggle toggle-file">FILE</button>
+    </div>
+    <div class="column">
+        <button data-js-selector="data-source-toggle" data-source="url" class="toggle toggle-url">URL</button>
+    </div>
+</div>
+
+<div class="row extra-spacing">
+    <div class="column">
+        <button data-js-selector="file-type-toggle" data-type="csv" class="toggle toggle-csv">CSV</button>
+    </div>
+    <div class="column">
+        <button data-js-selector="file-type-toggle" data-type="tsv" class="toggle toggle-tsv">TSV</button>
+    </div>
+    <div class="column">
+        <button data-js-selector="file-type-toggle" data-type="json" class="toggle toggle-json">JSON</button>
+    </div>
+</div>
+
+<form class="file-upload-form" data-js-selector="file-upload-form">
+    <div class="row">
+        <input type="file" class="file-upload-input">
     </div>
 
-    <button class="button red upload-button">
-        <span class="ready-state">upload</span>
-        <span class="loading-state">loading...</span>
-    </button>
+    <div class="row">
+        <button type="submit" class="button red">
+            <span class="ready-state">UPLOAD</span>
+            <span class="loading-state">LOADING ...</span>
+        </button>
+    </div>
+</form>
+
+<form class="url-form" data-js-selector="url-form">
+    <div>
+        <input type="text" placeholder="URL to a file" class="text-input url-input" data-js-selector="url-input" id="url">
+    </div>
+
+    <div class="row">
+        <button class="button red">
+            <span class="ready-state">UPLOAD</span>
+            <span class="loading-state">LOADING ...</span>
+        </button>
+    </div>
 </form>

--- a/src/views/Uploader.js
+++ b/src/views/Uploader.js
@@ -10,78 +10,165 @@ var dispatcher = require('../dispatcher');
 /**
  * ## Upload Form View
  *
- * Contains logic of uploading files into data lasso
- * to be visualized.
- *
+ * Handles UI and logic of loading data into Data Lasso
+ * either using file or by requesting dataset from a URL
  */
 
 var UploaderView = Backbone.View.extend({
 
     className: 'uploader',
 
+    /**
+     * What source type is currently selected
+     */
+    dataSource: 'file',
+
+    /**
+     * What format is the data source
+     */
+    fileType: 'csv',
+
     events: {
-        'submit form': 'onFormSubmit',
+        'click [data-js-selector="data-source-toggle"]': 'onDataSourceClick',
+        'click [data-js-selector="file-type-toggle"]': 'onFileTypeClick',
+
+        'submit [data-js-selector="file-upload-form"]': 'onFileFormSubmit',
+        'submit [data-js-selector="url-form"]': 'onUrlFormSubmit',
     },
 
     /**
-     * Get whatever filetype was checked
+     * Event handler for data source toggle click. Sets
+     * `data-source` attribute on the $el to match selected data source
      *
-     * @returns {string} : Either 'csv', 'tsv' or 'json'
+     * @param e - DOM Event
      */
-    getSelectedType: function () {
-        var $selectedToggle = this.$formatToggles.filter(':checked');
-        return $selectedToggle.val();
+    onDataSourceClick: function (e) {
+        var source = $(e.target).attr('data-source');
+        this.$el.attr('data-source', source);
     },
 
     /**
-     * Event listener for form submit event
+     * Event handler for file type toggle click. Sets
+     * `data-file-type` attribute on the $el to match selected file type
+     *
+     * @param e - DOM Event
      */
-    onFormSubmit: function (e) {
+    onFileTypeClick: function (e) {
+        var type = $(e.target).attr('data-type');
+        this.$el.attr('data-file-type', type);
+    },
+
+    /**
+     * Event listener for file upload form submit event
+     *
+     * @param e - DOM Event from which we get reference to file input
+     */
+    onFileFormSubmit: function (e) {
         e.preventDefault();
 
-        var file = this.$fileUpload[0].files[0];
-
+        var file = e.target[0].files[0];
         if (file) {
+            this.setLoadingIndicator(true);
             var reader = new FileReader();
-            reader.onload = _.bind(this.readerOnload, this);
+            reader.onload = _.bind(function (e) {
+                this.loadData(e.target.result);
+            }, this);
             reader.readAsText(file);
-            this.toggleLoadingIndicator();
         }
     },
 
     /**
-     * Callback for when file was accepted and read. Parses file
-     * into an object and passes it further down the flow
+     * Event listener for url form submit event
+     *
+     * @param e - DOM Event from which we get URL to use
      */
-    readerOnload: function (e) {
-        var entries;
+    onUrlFormSubmit: function (e) {
+        e.preventDefault();
 
-        switch (this.getSelectedType()) {
-            case 'csv':
-                entries = d3.csv.parse(e.target.result);
-                break;
-            case 'tsv':
-                entries = d3.tsv.parse(e.target.result);
-                break;
-            case 'json':
-                entries = JSON.parse(e.target.result);
-                break;
+        var url = e.target[0].value;
+        if (url) {
+            this.setLoadingIndicator(true);
+            $.get(url)
+                .then(_.bind(this.loadData, this))
+                .fail(_.bind(this.onRequestFail, this));
         }
-
-        dispatcher.dispatch({actionType: 'file-uploaded', entries: entries});
-
-        this.listenToOnce(store, 'change:entries', this.toggleLoadingIndicator());
     },
 
-    toggleLoadingIndicator: function () {
-        this.$el.toggleClass('loading');
+    onRequestFail: function (jqXHR, status, error) {
+        this.setLoadingIndicator(false);
+        this.displayError(error);
+    },
+
+    /**
+     * Parses file into an object based on it's type.
+     * Uses d3's parsing to parse a string to an object
+     *
+     * @param {string} data - String to parse
+     * @return {object} - List of entries to visualize
+     */
+    parseFile: function (data) {
+        try {
+            switch (this.fileType) {
+                case 'csv':
+                    return d3.csv.parse(data);
+                case 'tsv':
+                    return d3.tsv.parse(data);
+                case 'json':
+                    return JSON.parse(data);
+            }
+        } catch (e) {
+            this.displayError(e);
+            return null
+        }
+    },
+
+    /**
+     * Load the data to Data Lasso. Attempts to parse
+     * uploaded or requested file first, and updates the state if succesfull.
+     *
+     * @param {string} data - String containg file that was uploaded or requested
+     */
+    loadData: function (data) {
+        if (data) {
+            var entries = this.parseFile(data);
+
+            if (entries) {
+                this.listenToOnce(store, 'change:entries', _.bind(this.setLoadingIndicator, this, false));
+                dispatcher.dispatch({actionType: 'file-uploaded', entries: entries});
+            } else {
+                this.setLoadingIndicator(false);
+            }
+        } else {
+            this.displayError();
+        }
+    },
+
+    /**
+     * Sets loading state on the Uploader component by
+     * adding or removing `loading` class
+     *
+     * @param {boolean} isLoading - Should interface be seen as loading
+     */
+    setLoadingIndicator: function (isLoading) {
+        this.$el.toggleClass('loading', isLoading);
+    },
+
+    /**
+     * Display an error state to the user by applying an
+     * animation that is added with `error` class
+     */
+    displayError: function () {
+        this.$el.addClass('error');
+        this.$el.on('animationend', _.bind(function () {
+            this.$el.removeClass('error');
+        }, this));
     },
 
     render: function () {
         this.$el.html(template());
 
-        this.$fileUpload = this.$('[type="file"]');
-        this.$formatToggles = this.$('[name="type"]');
+        this.$el.attr('data-source', this.dataSource);
+        this.$el.attr('data-file-type', this.fileType);
 
         return this;
     },


### PR DESCRIPTION
# URL Upload

## Why
If your data set is accessible on the internets, you can now enter a link and have Data Lasso load it for you. That is especially useful when you are working with large data sets that you don't want to download on your machine just to upload again to Data Lasso.

## What's here
- This adds functionality to existing Uploader view. Now you can upload a file _and_ specify a URL where to get the data from
- Adds an error state (button shake) when something went wrong
- Makes loading state more obvious when using uploader

## Testing
- File uploads should work the same
- URL uploads should work. Can be tested with a sample dataset here: `http://tumblr.github.io/data-lasso/samples/UCS_Satellite_Database.csv`
- With bad datasets (or network request errors), you should get an error shake now

@heylookltsme @kmck 